### PR TITLE
Set the default value of chunk_size to nil

### DIFF
--- a/lib/fluent/plugin/s3_compressor_arrow.rb
+++ b/lib/fluent/plugin/s3_compressor_arrow.rb
@@ -16,7 +16,7 @@ module Fluent::Plugin
         config_param :format, :enum, list: [:arrow, :feather, :parquet], default: :arrow
         SUPPORTED_COMPRESSION = [:gzip, :snappy, :zstd]
         config_param :compression, :enum, list: SUPPORTED_COMPRESSION, default: nil
-        config_param :chunk_size, :integer, default: 1024
+        config_param :chunk_size, :integer, default: nil
       end
 
       def configure(conf)
@@ -45,11 +45,13 @@ module Fluent::Plugin
         stream = Arrow::BufferInputStream.new(buffer)
         table = Arrow::JSONReader.new(stream, @options)
 
-        table.read.save(tmp,
+        save_options = {
           format: @arrow.format,
-          chunk_size: @arrow.chunk_size,
           compression: @arrow.compression,
-        )
+        }
+        save_options[:chunk_size] = @arrow.chunk_size if @arrow.chunk_size
+        
+        table.read.save(tmp,save_options)
       end
     end
   end

--- a/lib/fluent/plugin/s3_compressor_arrow.rb
+++ b/lib/fluent/plugin/s3_compressor_arrow.rb
@@ -45,13 +45,11 @@ module Fluent::Plugin
         stream = Arrow::BufferInputStream.new(buffer)
         table = Arrow::JSONReader.new(stream, @options)
 
-        save_options = {
+        table.read.save(tmp,
           format: @arrow.format,
+          chunk_size: @arrow.chunk_size,
           compression: @arrow.compression,
-        }
-        save_options[:chunk_size] = @arrow.chunk_size if @arrow.chunk_size
-        
-        table.read.save(tmp,save_options)
+        )
       end
     end
   end

--- a/test/plugin/test_s3_compressor_arrow.rb
+++ b/test/plugin/test_s3_compressor_arrow.rb
@@ -22,7 +22,6 @@ class S3OutputTest < Test::Unit::TestCase
       assert_equal :arrow, c.ext
       assert_equal 'application/x-apache-arrow-file', c.content_type
       assert c.instance_variable_get(:@schema).is_a?(Arrow::Schema)
-      assert_equal 1024, c.instance_variable_get(:@arrow).chunk_size
     end
 
     data(


### PR DESCRIPTION
Because Arrow 2.0 uses a more desirable default value.